### PR TITLE
Prevent error with python based servers.

### DIFF
--- a/source/XLSPClient.pas
+++ b/source/XLSPClient.pas
@@ -1283,7 +1283,7 @@ begin
         raise XLSPException.CreateRes(@rsInitializeFailure);
 
       // Send Initialized notification to the server
-      SendNotification(lspInitialized);
+      SendNotification(lspInitialized, '', nil, '{}');
 
       // OnInitialized event
       if Assigned(FOnInitialized) then


### PR DESCRIPTION
For some weird reason the official Microsoft LSP translation of the protocol to python has an error.

See https://github.com/microsoft/lsprotocol/blob/e55a4cfbdf0f88587eafa91761a9c08ea27aca82/packages/python/lsprotocol/types.py#L11560

In InitializedNotification params is not declared optional and this raises an error with servers written in python.    Compare for instance with ExitNotification where params is declared optional.

This PR fixes this. 


UPDATE:  Actually the translation is not wrong.  See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized

The params is not optional!