### PR TITLE
Align with D13

### DIFF
--- a/source/XLSPClient.pas
+++ b/source/XLSPClient.pas
@@ -2308,11 +2308,8 @@ end;
 
 function TLSPClient.SendSyncRequest(const lspKind: TLSPKind; params:
     TLSPBaseParams; Handler: TLSPResponseHandler; Timeout: Integer): Boolean;
-var
-  Id: Integer;
 begin
-  Id := SendRequest(lspKind, params, Handler);
-  FSyncRequestId := Id;
+  FSyncRequestId := SendRequest(lspKind, params, Handler);
   // Wait for the responze
   Result := FSyncRequestEvent.WaitFor(Timeout) = wrSignaled;
   FSyncRequestEvent.ResetEvent;

--- a/source/XLSPClient.pas
+++ b/source/XLSPClient.pas
@@ -1924,6 +1924,9 @@ begin
         end;
       end;
     end;
+    lspDidChangeWorkspaceFolders:
+      Result := Assigned(ServerCapabilities) and
+                ServerCapabilities.workspace.workspaceFolders.changeNotifications;
     lspWorkspaceSymbol:
       Result := Assigned(ServerCapabilities.workspaceSymbolProvider);
     lspWorkspaceExecuteCommand:

--- a/source/XLSPFunctions.pas
+++ b/source/XLSPFunctions.pas
@@ -289,7 +289,7 @@ begin
     end;
     initObj.capabilities.textDocument.semanticTokens.requests.full := SFull;
   end;
-  Result := initObj.AsJSON([TSerializeOption.IgnoreNil, TSerializeOption.IgnoreEmpty]);
+  Result := initObj.AsJSON(True);
 end;
 
 function JsonCallHierarchyIncommingResultToObject(
@@ -1299,13 +1299,13 @@ begin
 
   case lspKind of
     lspInitialize:                    Result := LSPInitializeParamsToJSON(TLSPInitializeParams(Params));
-    lspDidSaveTextDocument:           Result := TLSPDidSaveTextDocumentParams(Params).AsJSON([TSerializeOption.IgnoreEmpty]);
+    lspDidSaveTextDocument:           Result := TLSPDidSaveTextDocumentParams(Params).AsJSON(True);
     lspCompletionItemResolve:         Result := TSerializer.Serialize(TLSPCompletionItemResolveParams(Params).completionItem);
     lspCodeActionResolve:             Result := TSerializer.Serialize(TLSPCodeActionResolveParams(Params).codeaction);
     lspCodeLensResolve:               Result := TSerializer.Serialize(TLSPCodeLensResolveParams(Params).codeLens);
     lspDocumentLinkResolve:           Result := TSerializer.Serialize(TLSPDocumentLinkResolveParams(Params).documentLink);
     lspInlayHintResolve:              Result := TSerializer.Serialize(TLSPInlayHintResolveParams(Params).inlayHint);
-    lspCompletion:                    Result := TLSPCompletionParams(Params).AsJSON([TSerializeOption.IgnoreEmpty]);
+    lspCompletion:                    Result := TLSPCompletionParams(Params).AsJSON(True);
   else
     Result := Params.AsJSON;
   end;

--- a/source/XLSPTypes.pas
+++ b/source/XLSPTypes.pas
@@ -3172,7 +3172,8 @@ type
     constructor Create;
     destructor Destroy; override;
     procedure AddRoot(const sz: string);
-    procedure AddWorkspaceFolders(const ls: TStringList);
+    procedure AddWorkspaceFolders(const stringArray: TArray<string>); overload;
+    procedure AddWorkspaceFolders(const ls: TStringList); overload;
   end;
 
   TLSPSaveOption = record
@@ -6057,22 +6058,27 @@ begin
   rootUri := FilePathToUri(sz);
 end;
 
-procedure TLSPInitializeParams.AddWorkspaceFolders(const ls: TStringList);
+procedure TLSPInitializeParams.AddWorkspaceFolders(
+  const stringArray: TArray<string>);
 var
-  i: Integer;
   s: string;
+  workspaceFolder: TLSPWorkspaceFolder;
 begin
-  // Set workspace folders
-  SetLength(workspaceFolders,ls.Count);
-  for i := 0 to ls.Count - 1 do
+  workspaceFolders := [];
+  for s in stringArray do
   begin
-    s := ls[i];
     if s <> '' then
     begin
-      workspaceFolders[i].uri := FilePathToUri(s);
-      workspaceFolders[i].name := ExtractFileName(s);
+      workspaceFolder.uri := FilePathToUri(s);
+      workspaceFolder.name := ExtractFileName(s);
+      workspaceFolders := workspaceFolders + [workspaceFolder];
     end;
   end;
+end;
+
+procedure TLSPInitializeParams.AddWorkspaceFolders(const ls: TStringList);
+begin
+  AddWorkspaceFolders(ls.ToStringArray);
 end;
 
 // TLSPClientCapabilities

--- a/source/XLSPTypes.pas
+++ b/source/XLSPTypes.pas
@@ -1561,10 +1561,18 @@ type
   end;
 
   TJsonTextEditDictConverter =
+    {$IF CompilerVersion < 37}
     class(TJsonTypedStringDictionaryConverter<TArray<TLSPAnnotatedTextEdit>>);
+    {$ELSE}
+    class(TJsonStringDictionaryConverter<TArray<TLSPAnnotatedTextEdit>>);
+    {$ENDIF}
 
   TJsonChangeAnnotationDictConverter =
+    {$IF CompilerVersion < 37}
     class(TJsonTypedStringDictionaryConverter<TLSPChangeAnnotation>);
+    {$ELSE}
+    class(TJsonStringDictionaryConverter<TLSPChangeAnnotation>);
+    {$ENDIF}
 
   TLSPWorkspaceEdit = class(TLSPBaseResult)
   public

--- a/source/XLSPTypes.pas
+++ b/source/XLSPTypes.pas
@@ -4809,6 +4809,7 @@ type
     // also be triggered when file content changes.
     const Automatic = 2;
   end;
+  TLSPDocumentSymbols = TArray<TLSPDocumentSymbol>;
 
   TLSPCodeActionContext = record
     // An array of diagnostics known on the client side overlapping the range

--- a/source/XLSPUtils.pas
+++ b/source/XLSPUtils.pas
@@ -121,10 +121,12 @@ type
   end;
 
   // Dictionary converter
+  {$IF CompilerVersion < 37}
   TJsonTypedStringDictionaryConverter<V> = class(TJsonStringDictionaryConverter<V>)
     function ReadJson(const AReader: TJsonReader; ATypeInf: PTypeInfo; const AExistingValue: TValue;
       const ASerializer: TJsonSerializer): TValue; override;
   end;
+  {$ENDIF}
 
   // BugFix for Delphi 11 or earlier
   {$IF CompilerVersion < 36}
@@ -402,7 +404,7 @@ begin
   Result := True;
 end;
 
-{$REGION 'Utility functions'}
+{$ENDREGION 'Utility functions'}
 
 
 {$REGION 'Helper classes'}
@@ -619,6 +621,7 @@ begin
   end;
 end;
 
+{$IF CompilerVersion < 37}
 type
   // Fix for https://embt.atlassian.net/servicedesk/customer/portal/1/RSS-3591
   TJSONObjectWriterHelper = class helper for TJSONObjectWriter
@@ -638,6 +641,7 @@ begin
         Result := nil;
     end;
 end;
+{$ENDIF}
 
 {$ENDREGION 'Helper classes'}
 
@@ -814,7 +818,11 @@ begin
     AWriter.WriteRawValue(AValue.AsString)
   else if AWriter is TJsonObjectWriter then
   begin
+    {$IF CompilerVersion < 37}
     JsonPair :=  TJsonObjectWriter(AWriter).FixedGetContainer as TJsonPair;
+    {$ELSE}
+    JsonPair :=  TJsonObjectWriter(AWriter).Container as TJsonPair;
+    {$ENDIF}
     AWriter.WriteNull;  // to pop the JSONpair
     JsonPair.JsonValue := TJSONValue.ParseJSONValue(AValue.AsString);
   end
@@ -852,6 +860,7 @@ end;
 
 { TTypedJsonStringDictionaryConverter<V> }
 
+{$IF CompilerVersion < 37}
 function TJsonTypedStringDictionaryConverter<V>.ReadJson(
   const AReader: TJsonReader; ATypeInf: PTypeInfo; const AExistingValue: TValue;
   const ASerializer: TJsonSerializer): TValue;
@@ -878,6 +887,7 @@ begin
     raise;
   end;
 end;
+{$ENDIF}
 
 { TJsonIntegerConverter }
 


### PR DESCRIPTION
- Exploit D13 new TJsonValueSerialization option.
- Removed fixes that were fixed in D13
- Made TJsonRawConverter.Read work with TJsonTextReader (a bit of hack).  However this avoids the intermediate conversion to TJsonObject.
- Remove Format from TSerializeOption and use RTL TJsonFormatting instead.
