### PR TITLE
Implemented asynchronous writing in RunServer

### DIFF
--- a/source/XLSPExecute.pas
+++ b/source/XLSPExecute.pas
@@ -378,7 +378,7 @@ begin
             // Allocate overlapped
             New(ExtWriteOverlapped);
             ExtWriteOverlapped.PipeHandle := @StdInWritePipe;
-            ZeroMemory(@ExtOverlappedError.Overlapped, SizeOf(TOverlapped));
+            ZeroMemory(@ExtWriteOverlapped.Overlapped, SizeOf(TOverlapped));
 
             // Store the data for writing in ExtWriteOverlapped
             FWriteLock.Enter;

--- a/source/XLSPExecute.pas
+++ b/source/XLSPExecute.pas
@@ -268,7 +268,7 @@ begin
   ReadHandle := 0;
   WriteHandle := 0;
   try
-    // Create async pipe for writing
+    // Create async pipes for writing
     if not CreateAsyncPipePair(StdInReadPipe, StdInWriteTmpPipe, @SecurityAttributes, 0, False) then
       RaiseLastOSError;
 
@@ -281,11 +281,11 @@ begin
       SafeCloseHandle(StdInWriteTmpPipe);
     end;
 
-    // Create async pipe for reading stdout
+    // Create async pipes for reading stdout
     if not CreateAsyncPipePair(ReadHandle, WriteHandle, @SecurityAttributes, BUFFER_SIZE) then
       RaiseLastOSError;
 
-    // Create async pipe for reading stderror
+    // Create async pipes for reading stderror
     if not CreateAsyncPipePair(ErrorReadHandle, ErrorWriteHandle, @SecurityAttributes, BUFFER_SIZE) then
       RaiseLastOSError;
   except
@@ -400,8 +400,8 @@ begin
             end;
           end;
         WAIT_IO_COMPLETION: Continue;
-        else
-          RaiseLastOSError;
+      else
+        RaiseLastOSError;
       end;
     until (ErrorReadHandle = 0) and (ReadHandle = 0);
 


### PR DESCRIPTION
Apart from being more efficient (writing to the server does not block and you can process input while writing), it also fixes a (rare) bug I encountered, in which the connection failed when the system read pipe buffer became full, whilst WriteFile was blocking the reading, preventing the server from sending responses to the client.  

Explanation: 
This happened while sending didOpen notifications for many large files and requesting document symbols on editor startup.
The internal pipe buffer is 64K (Windows system default) and in my case the response was 200 Kb+.   While RunServer was busy writing, the server got an error while sending responses due to the full pipe buffer and crashed.